### PR TITLE
Dev feature 3 - Mutable Templates

### DIFF
--- a/include/atomicassets.hpp
+++ b/include/atomicassets.hpp
@@ -129,6 +129,13 @@ public:
         ATTRIBUTE_MAP new_mutable_data
     );
 
+    ACTION settempldata(
+        name authorized_editor,
+        name collection_name,
+        name schema_name,
+        int32_t template_id,
+        ATTRIBUTE_MAP new_mutable_data
+    );
 
     ACTION announcedepo(
         name owner,
@@ -233,6 +240,14 @@ public:
         ATTRIBUTE_MAP new_data
     );
 
+    ACTION logsetdatatl(
+        name collection_name,
+        name schema_name,
+        int32_t template_id, 
+        ATTRIBUTE_MAP old_data,
+        ATTRIBUTE_MAP new_data
+    );
+
     ACTION logbackasset(
         name asset_owner,
         uint64_t asset_id,
@@ -295,6 +310,15 @@ private:
 
     typedef multi_index <name("templates"), templates_s> templates_t;
 
+    //Scope: collection_name
+    TABLE template_data_s {
+        int32_t          template_id;
+        vector <uint8_t> mutable_serialized_data;
+
+        uint64_t primary_key() const { return (uint64_t) template_id; }
+    };
+
+    typedef multi_index <name("templatedata"), template_data_s> template_data_t;
 
     //Scope: owner
     TABLE assets_s {
@@ -408,4 +432,6 @@ private:
     schemas_t get_schemas(name collection_name);
 
     templates_t get_templates(name collection_name);
+    
+    template_data_t get_template_data(name collection_name);
 };

--- a/include/atomicassets.hpp
+++ b/include/atomicassets.hpp
@@ -104,6 +104,17 @@ public:
         ATTRIBUTE_MAP immutable_data
     );
 
+    ACTION createtempl2(
+        name authorized_creator,
+        name collection_name,
+        name schema_name,
+        bool transferable,
+        bool burnable,
+        uint32_t max_supply,
+        ATTRIBUTE_MAP immutable_data,
+        ATTRIBUTE_MAP mutable_data
+    );
+
     ACTION locktemplate(
         name authorized_editor,
         name collection_name,
@@ -313,6 +324,7 @@ private:
     //Scope: collection_name
     TABLE template_data_s {
         int32_t          template_id;
+        name             schema_name;
         vector <uint8_t> mutable_serialized_data;
 
         uint64_t primary_key() const { return (uint64_t) template_id; }
@@ -394,6 +406,16 @@ private:
     config_t       config       = config_t(get_self(), get_self().value);
     tokenconfigs_t tokenconfigs = tokenconfigs_t(get_self(), get_self().value);
 
+    void create_template(
+        name & authorized_creator,
+        name & collection_name,
+        name & schema_name,
+        bool transferable,
+        bool burnable,
+        uint32_t max_supply,
+        ATTRIBUTE_MAP immutable_data,
+        ATTRIBUTE_MAP mutable_data
+    );
 
     void internal_transfer(
         name from,

--- a/include/atomicassets.hpp
+++ b/include/atomicassets.hpp
@@ -104,7 +104,7 @@ public:
         ATTRIBUTE_MAP immutable_data
     );
 
-    ACTION createtempl2(
+    ACTION createtempl(
         name authorized_creator,
         name collection_name,
         name schema_name,
@@ -413,8 +413,8 @@ private:
         bool transferable,
         bool burnable,
         uint32_t max_supply,
-        ATTRIBUTE_MAP immutable_data,
-        ATTRIBUTE_MAP mutable_data
+        ATTRIBUTE_MAP & immutable_data,
+        ATTRIBUTE_MAP mutable_data = {}
     );
 
     void internal_transfer(

--- a/src/atomicassets.cpp
+++ b/src/atomicassets.cpp
@@ -1318,6 +1318,11 @@ void atomicassets::create_template(
     int32_t template_id = current_config.template_counter++;
     config.set(current_config, get_self());
 
+    if (transferable == false){
+        check(burnable == true, 
+            "A template cannot be both non-transferable and non-burnable");
+    }
+
     templates_t collection_templates = get_templates(collection_name);
 
     check_name_length(immutable_data);

--- a/src/atomicassets.cpp
+++ b/src/atomicassets.cpp
@@ -419,7 +419,7 @@ ACTION atomicassets::createtempl(
     uint32_t max_supply,
     ATTRIBUTE_MAP immutable_data
 ) {  
-    create_template(authorized_creator, collection_name, schema_name, transferable, burnable, max_supply, immutable_data, {});
+    create_template(authorized_creator, collection_name, schema_name, transferable, burnable, max_supply, immutable_data);
 }
 
 /**
@@ -427,7 +427,7 @@ ACTION atomicassets::createtempl(
 *  @required_auth authorized_creator, who is within the authorized_accounts list of the collection
 */
 
-ACTION atomicassets::createtempl2(
+ACTION atomicassets::createtempl(
     name authorized_creator,
     name collection_name,
     name schema_name,
@@ -439,6 +439,7 @@ ACTION atomicassets::createtempl2(
 ) {  
     create_template(authorized_creator, collection_name, schema_name, transferable, burnable, max_supply, immutable_data, mutable_data);
 }
+
 
 /**
 * Sets the max supply of the template to the issued supply
@@ -1295,7 +1296,7 @@ void atomicassets::create_template(
     bool transferable,
     bool burnable,
     uint32_t max_supply,
-    ATTRIBUTE_MAP immutable_data,
+    ATTRIBUTE_MAP & immutable_data,
     ATTRIBUTE_MAP mutable_data
 ) { 
     require_auth(authorized_creator);


### PR DESCRIPTION
- Adds Mutable Template Table with template_id key and schema_name + serialized_mutable_data fields
- Adds polymorph of createtempl action for backwards compatibility to allow creating templates with explicit mutable data
