### PR TITLE
Dev feature 4 - Media Types for Schemas

### DIFF
--- a/include/atomicassets.hpp
+++ b/include/atomicassets.hpp
@@ -93,6 +93,12 @@ public:
         vector <FORMAT> schema_format_extension
     );
 
+    ACTION setschematyp(
+        name authorized_creator,
+        name collection_name,
+        name schema_name,
+        vector <FORMAT_TYPE> schema_format_type
+    );
 
     ACTION createtempl(
         name authorized_creator,
@@ -279,6 +285,15 @@ private:
 
     typedef multi_index <name("schemas"), schemas_s> schemas_t;
 
+    //Scope: collection_name
+    TABLE schema_types_s {
+        name            schema_name;
+        vector <FORMAT_TYPE> format_type;
+
+        uint64_t primary_key() const { return schema_name.value; }
+    };
+
+    typedef multi_index <name("schematypes"), schema_types_s> schema_types_t;
 
     //Scope: collection_name
     TABLE templates_s {
@@ -406,6 +421,8 @@ private:
     assets_t get_assets(name acc);
 
     schemas_t get_schemas(name collection_name);
+
+    schema_types_t get_schema_types(name collection_name);
 
     templates_t get_templates(name collection_name);
 };

--- a/include/atomicdata.hpp
+++ b/include/atomicdata.hpp
@@ -37,6 +37,12 @@ namespace atomicdata {
         std::string type;
     };
 
+    struct FORMAT_TYPE {
+        std::string name;
+        std::string mediatype;
+        std::string info;
+    };
+
     static constexpr uint64_t RESERVED = 4;
 
 

--- a/src/atomicassets.cpp
+++ b/src/atomicassets.cpp
@@ -440,8 +440,8 @@ ACTION atomicassets::setschematyp(
     auto & schema_format = schema_itr->format;
 
     for (auto a = 0; a < schema_format.size(); a++){
-        auto itr_f = schema_format.at(a);
-        auto itr_t = schema_format_type.at(a);
+        auto & itr_f = schema_format.at(a);
+        auto & itr_t = schema_format_type.at(a);
         check(itr_f.name == itr_t.name, 
             "Mismatch between schema format names");
     }

--- a/src/atomicassets.cpp
+++ b/src/atomicassets.cpp
@@ -404,6 +404,59 @@ ACTION atomicassets::extendschema(
     });
 }
 
+/**
+*  Creates a new schema
+*  schemas can only be extended in the future, but never changed retroactively.
+*  This guarantees a correct deserialization for existing templates and assets.
+*  @required_auth authorized_creator, who is within the authorized_accounts list of the collection
+*/
+ACTION atomicassets::setschematyp(
+    name authorized_creator,
+    name collection_name,
+    name schema_name,
+    vector <FORMAT_TYPE> schema_format_type
+) {
+    require_auth(authorized_creator);
+
+    auto collection_itr = collections.require_find(collection_name.value,
+        "No collection with this name exists");
+
+    check_has_collection_auth(
+        authorized_creator,
+        collection_name,
+        "The creator is not authorized within the collection"
+    );
+
+    schemas_t collection_schemas = get_schemas(collection_name);
+    auto schema_itr = collection_schemas.require_find(schema_name.value,
+        "Schema name not found within the collection");
+
+    schema_types_t collection_schema_types = get_schema_types(collection_name);
+    auto schema_types_itr = collection_schema_types.find(schema_name.value);
+
+    check(schema_itr->format.size() == schema_format_type.size(), 
+        "Schema Types must be equal in length / size to the original format of the Schema");
+    
+    auto & schema_format = schema_itr->format;
+
+    for (auto a = 0; a < schema_format.size(); a++){
+        auto itr_f = schema_format.at(a);
+        auto itr_t = schema_format_type.at(a);
+        check(itr_f.name == itr_t.name, 
+            "Mismatch between schema format names");
+    }
+
+    if (schema_types_itr == collection_schema_types.end()){
+        collection_schema_types.emplace(authorized_creator, [&](auto &_schema_types) {
+            _schema_types.schema_name = schema_name;
+            _schema_types.format_type = schema_format_type;
+        });
+    } else {
+        collection_schema_types.modify(schema_types_itr, authorized_creator, [&](auto &_schema_types) {
+            _schema_types.format_type = schema_format_type;
+        });
+    }
+}
 
 /**
 *  Creates a new template
@@ -1479,6 +1532,9 @@ atomicassets::schemas_t atomicassets::get_schemas(name collection_name) {
     return schemas_t(get_self(), collection_name.value);
 }
 
+atomicassets::schema_types_t atomicassets::get_schema_types(name collection_name) {
+    return schema_types_t(get_self(), collection_name.value);
+}
 
 atomicassets::templates_t atomicassets::get_templates(name collection_name) {
     return templates_t(get_self(), collection_name.value);


### PR DESCRIPTION
- Adds FORMAT_TYPE struct in atomicdata.hpp with name, mediatype & info fields
- Adds schematypes table with collection_name scope, schema_name key & FORMAT_TYPE vector 
- Validates schema's format & format_type to ensure no mismatches