### PR TITLE
Dev Feature 5 - Changing Collection Authors

### DIFF
--- a/include/atomicassets.hpp
+++ b/include/atomicassets.hpp
@@ -11,7 +11,7 @@ using namespace atomicdata;
 
 
 static constexpr double MAX_MARKET_FEE = 0.15;
-static constexpr uint32_t AUTHOR_SWAP_TIME_DELTA = 604800; // 1 week, valid for 3 weeks
+static constexpr uint32_t AUTHOR_SWAP_TIME_DELTA = 60 * 60 * 24 * 7; // 1 week, valid for 1 week
 
 
 CONTRACT atomicassets : public contract {
@@ -82,7 +82,7 @@ public:
     ACTION createauswap(
         name collection_name,
         name new_author,
-        name permission
+        bool owner
     );
     
     ACTION acceptauswap(
@@ -272,8 +272,7 @@ private:
         name             collection_name;
         name             current_author;
         name             new_author;
-        name             permission;
-        uint32_t         swap_date;
+        uint32_t         acceptance_date;
 
         uint64_t primary_key() const { return collection_name.value; };
     };

--- a/include/atomicassets.hpp
+++ b/include/atomicassets.hpp
@@ -11,6 +11,7 @@ using namespace atomicdata;
 
 
 static constexpr double MAX_MARKET_FEE = 0.15;
+static constexpr uint32_t AUTHOR_SWAP_TIME_DELTA = 604800; // 1 week, valid for 3 weeks
 
 
 CONTRACT atomicassets : public contract {
@@ -78,6 +79,19 @@ public:
         name collection_name
     );
 
+    ACTION createauswap(
+        name collection_name,
+        name new_author,
+        name permission
+    );
+    
+    ACTION acceptauswap(
+        name collection_name
+    );
+
+    ACTION rejectauswap(
+        name collection_name
+    );
 
     ACTION createschema(
         name authorized_creator,
@@ -254,6 +268,18 @@ public:
 
 private:
 
+    TABLE author_swaps_s {
+        name             collection_name;
+        name             current_author;
+        name             new_author;
+        name             permission;
+        uint32_t         swap_date;
+
+        uint64_t primary_key() const { return collection_name.value; };
+    };
+
+    typedef multi_index <name("authorswaps"), author_swaps_s> author_swaps_t;
+
     TABLE collections_s {
         name             collection_name;
         name             author;
@@ -363,7 +389,7 @@ private:
     // https://github.com/EOSIO/eosio.cdt/issues/280
     typedef multi_index <name("tokenconfigs"), tokenconfigs_s> tokenconfigs_t_for_abi;
 
-
+    author_swaps_t authorswaps  = author_swaps_t(get_self(), get_self().value);
     collections_t  collections  = collections_t(get_self(), get_self().value);
     offers_t       offers       = offers_t(get_self(), get_self().value);
     balances_t     balances     = balances_t(get_self(), get_self().value);

--- a/src/atomicassets.cpp
+++ b/src/atomicassets.cpp
@@ -327,6 +327,102 @@ ACTION atomicassets::forbidnotify(
     });
 }
 
+/**
+* Creates a swap offer for a collection
+* Acceptance functionality depends on the authorization being 'owner' or 'active' (7 days gate)
+*/
+
+ACTION atomicassets::createauswap(
+    name collection_name,
+    name new_author,
+    name permission
+) {
+    auto collection_itr = collections.require_find(collection_name.value,
+        "No collection with this name exists");
+
+    if (permission == name("owner")){
+        require_auth(permission_level{collection_itr->author, name("owner")});
+    } else {
+        check(permission == name("active"), 
+            "Only 'owner' or 'active' permissions can create an author swap");
+        require_auth(permission_level{collection_itr->author, name("active")});
+    }
+
+    check(authorswaps.find(collection_name.value) == authorswaps.end(), 
+        "Can't swap author's while an authorswap is underway for this collection");
+    
+    authorswaps.emplace(collection_itr->author, [&](auto &_author_swaps) {
+        _author_swaps.collection_name = collection_name;
+        _author_swaps.current_author = collection_itr->author;
+        _author_swaps.new_author = new_author;
+        _author_swaps.permission = permission;
+        _author_swaps.swap_date = eosio::current_time_point().sec_since_epoch();
+    });
+}
+
+/**
+* Accepts an author swap, with time constraints based on 'owner' or 'active' permissions used when creating the author swap
+* With default parameters, author swaps created by 'active' permissions can only be accepted after 1 week has passed
+* With default parameters, author swaps remain valid for up to 3 weeks
+*/
+
+ACTION atomicassets::acceptauswap(
+    name collection_name
+) {
+    auto collection_itr = collections.require_find(collection_name.value,
+        "No collection with this name exists");
+
+    auto author_swaps_itr = authorswaps.require_find(collection_name.value,
+        "No author swaps for this collection found");
+
+    // Just in case**
+    check(collection_itr->author == author_swaps_itr->current_author, 
+        "Current author mismatch");
+
+    uint32_t now = eosio::current_time_point().sec_since_epoch();
+
+    if (author_swaps_itr->permission == name("owner")){
+        require_auth(permission_level{author_swaps_itr->new_author, name("owner")});
+    } else {    
+        check (author_swaps_itr->swap_date + AUTHOR_SWAP_TIME_DELTA < now, 
+            ("Active permission can only accept an author swap after " + to_string(AUTHOR_SWAP_TIME_DELTA) + " seconds have passed. [ " +
+            to_string(now - author_swaps_itr->swap_date + AUTHOR_SWAP_TIME_DELTA) + " ] seconds remaining").c_str());
+
+        require_auth(permission_level{collection_itr->author, name("active")});
+    }
+
+    check (now < author_swaps_itr->swap_date + (AUTHOR_SWAP_TIME_DELTA * 3), "Author swap for this collection has expired");
+
+    collections.modify(collection_itr, author_swaps_itr->new_author, [&](auto &_collection){
+        _collection.author = author_swaps_itr->new_author;
+    });
+
+    authorswaps.erase(author_swaps_itr);
+}
+
+/**
+* Rejects author swaps
+* Can be used by either the current author or by the new author
+*/
+
+ACTION atomicassets::rejectauswap(
+    name collection_name
+) {
+    auto collection_itr = collections.require_find(collection_name.value,
+        "No collection with this name exists");
+
+    auto author_swaps_itr = authorswaps.require_find(collection_name.value,
+        "No author swaps for this collection found");
+    
+    // Just in case**
+    check(collection_itr->author == author_swaps_itr->current_author, 
+        "Current author mismatch");
+
+    check(has_auth(author_swaps_itr->current_author) || has_auth(author_swaps_itr->new_author), 
+        "Missing required authorizations");
+    
+    authorswaps.erase(author_swaps_itr);
+}
 
 /**
 *  Creates a new schema


### PR DESCRIPTION
- Adds authorswaps table with collection_name key and current_author, new_author, permission and swap_date fields
- Current authors are able to create "author swap listings" with must then be accepted by the recipient "new_author"
- Author swaps can be accepted immediately if the permissions used to create the listing are 'owner'
- Author swaps can be accepted after 1 week (by default) if the permissions used to create the listings are 'active'
- Author swaps can be rejected / declined / erased by both the current_author & the new_author at any given time
- Author swaps expire after 3 weeks (by default) & must be destroyed & then recreated (just for safety purposes)