### PR TITLE
Dev Feature 8 - Contract Wide CPU Optimizations

### DIFF
--- a/include/atomicassets.hpp
+++ b/include/atomicassets.hpp
@@ -11,7 +11,7 @@ using namespace atomicdata;
 
 
 static constexpr double MAX_MARKET_FEE = 0.15;
-
+static const string MISSING_COLLECTION_AUTH = "Missing authorization for this collection";
 
 CONTRACT atomicassets : public contract {
 public:
@@ -352,25 +352,27 @@ private:
         vector <extended_symbol> supported_tokens  = {};
     };
     typedef singleton <name("config"), config_s>               config_t;
-    // https://github.com/EOSIO/eosio.cdt/issues/280
-    typedef multi_index <name("config"), config_s>             config_t_for_abi;
+
 
     TABLE tokenconfigs_s {
         name        standard = name("atomicassets");
         std::string version  = string("1.3.1");
     };
     typedef singleton <name("tokenconfigs"), tokenconfigs_s>   tokenconfigs_t;
-    // https://github.com/EOSIO/eosio.cdt/issues/280
-    typedef multi_index <name("tokenconfigs"), tokenconfigs_s> tokenconfigs_t_for_abi;
 
+    // Table Fetches
+    collections_t  get_collections() {return collections_t(get_self(), get_self().value);}
+    collections_t  get_collections_data() {return collections_t(get_self(), name("coldata").value);}
+    offers_t       get_offers() {return offers_t(get_self(), get_self().value);}
+    balances_t     get_balances() {return balances_t(get_self(), get_self().value);}
+    config_t       get_config() {return config_t(get_self(), get_self().value);}
+    tokenconfigs_t get_tokenconfigs() {return tokenconfigs_t(get_self(), get_self().value);}
 
-    collections_t  collections  = collections_t(get_self(), get_self().value);
-    offers_t       offers       = offers_t(get_self(), get_self().value);
-    balances_t     balances     = balances_t(get_self(), get_self().value);
-    config_t       config       = config_t(get_self(), get_self().value);
-    tokenconfigs_t tokenconfigs = tokenconfigs_t(get_self(), get_self().value);
+    assets_t       get_assets(name acc) {return assets_t(get_self(), acc.value);}
+    schemas_t      get_schemas(name collection_name) {return schemas_t(get_self(), collection_name.value);}
+    templates_t    get_templates(name collection_name) {return templates_t(get_self(), collection_name.value);}
 
-
+    // Internal Functions
     void internal_transfer(
         name from,
         name to,
@@ -396,16 +398,12 @@ private:
     );
 
     void check_has_collection_auth(
-        name account_to_check,
-        name collection_name,
-        string error_message
+        name & account_to_check,
+        const collections_s & collection_itr
     );
 
-    void check_name_length(ATTRIBUTE_MAP data);
+    void check_name_length(ATTRIBUTE_MAP & data);
 
-    assets_t get_assets(name acc);
+    void coldata_cleanup(name & collection_name, const collections_s & collection_itr);
 
-    schemas_t get_schemas(name collection_name);
-
-    templates_t get_templates(name collection_name);
 };

--- a/include/checkformat.hpp
+++ b/include/checkformat.hpp
@@ -29,7 +29,7 @@ For a format to be valid, three things are checked:
 Note: This could all be done a lot cleaner by using regex or similar libraries
       However, using them would bloat up the contract size significantly.
 */
-void check_format(vector <FORMAT> lines) {
+void check_format(vector <FORMAT> & lines) {
 
     bool found_name = false;
 

--- a/include/checkformat.hpp
+++ b/include/checkformat.hpp
@@ -35,10 +35,10 @@ void check_format(vector <FORMAT> & lines) {
 
     vector <string> attribute_names = {};
 
-    for (FORMAT line : lines) {
+    for (FORMAT & line : lines) {
 
-        string name = line.name;
-        string type = line.type;
+        string & name = line.name;
+        string & type = line.type;
 
         check(name.length() != 0, "An attribute's name can't be empty");
         check(name.length() <= 64, "An attribute's name can only be 64 characters max");


### PR DESCRIPTION
Note: This merge is for demonstration purposes & will be rewritten as a final form once all of the other features are implemented.

Overall improvements are benchmarked with minting 100x templated assets, with no mutable or immutable data & 4 schema fields, resulting in:
- Current version: 4.25ms to 8.54ms range, average of 6.385ms
- Upgraded version: 3ms to 7ms range, average of 5ms
- Estimated 1ms to 1.5ms range of reduction in computation time
- Estimated 20% to 30% range of CPU cost reduction at the high end
- Estimated 5% to 8% range of CPU cost reduction in practice (due to more data being in mint asset actions, more schema fields, smaller collection's 'serialized_data')

**Table Fetch Improvements**
When a table fetch is defined as so:
```C++
config_t config = config_t(get_self(), get_self().value);
```

It makes it so that the table is initialized & stored in memory on every single action call to the contract (including inline actions to itself, such as the logs). Essentially, something like 10x tables are being initialized every single time the contract executes any action, adding an unnecessary overhead to CPU costs. 

They have been rewritten to be as so:
```C++
config_t get_config() {return config_t(get_self(), get_self().value);}
```

Making it so that they are initialized only when the function is called instead of being implicitly initialized, helping mitigate CPU costs. All table fetches have been redefine according to this format.

**Collection Data Improvements**
All collections' table fetches are consuming (up to) an extra 3kb of on-chain data stored under the 'serialized_data' field, which no smart contract actually needs to interact with. This data is then fetched again during logs, making it so that every 'mintasset' & 'setassetdata' action is fetching (up to) 6kb of unnecessary data. 

This upgrade moves the 'serialized_data' to the **'coldata'** scope using the same primary_key, as well as implementing automatic conversions to this new approach upon any interaction with a collections' fees, authorized_accounts, notify_accounts or serialized_data. 

Further more, 'check_has_collection_auth' has been rewritten to be more CPU performative by not performing a "find" operation on the collections table twice by passing the collection_itr pointer to the function directly

**Reference Improvements**
Makes the **'check_name_length'** & **'check_format'** functions operate on data by reference instead of by value, preventing unnecessary copies 