### PR TITLE
Dev Production (1-8, 300)

### DIFF
--- a/include/atomicassets-interface.hpp
+++ b/include/atomicassets-interface.hpp
@@ -49,6 +49,29 @@ namespace atomicassets {
         string type;
     };
 
+    struct FORMAT_TYPE {
+        std::string name;
+        std::string mediatype;
+        std::string info;
+    };
+
+    /*
+        **************
+        *** Tables ***
+        **************
+    */
+
+    struct author_swaps_s {
+        name             collection_name;
+        name             current_author;
+        name             new_author;
+        uint32_t         acceptance_date;
+
+        uint64_t primary_key() const { return collection_name.value; };
+    };
+    typedef multi_index <name("authorswaps"), author_swaps_s> author_swaps_t;
+
+
     struct collections_s {
         name             collection_name;
         name             author;
@@ -60,7 +83,6 @@ namespace atomicassets {
 
         uint64_t primary_key() const { return collection_name.value; };
     };
-
     typedef multi_index <name("collections"), collections_s> collections_t;
 
 
@@ -71,8 +93,17 @@ namespace atomicassets {
 
         uint64_t primary_key() const { return schema_name.value; }
     };
-
     typedef multi_index <name("schemas"), schemas_s> schemas_t;
+
+
+    //Scope: collection_name
+    struct schema_types_s {
+        name            schema_name;
+        vector <FORMAT_TYPE> format_type;
+
+        uint64_t primary_key() const { return schema_name.value; }
+    };
+    typedef multi_index <name("schematypes"), schema_types_s> schema_types_t;
 
 
     //Scope: collection_name
@@ -87,8 +118,18 @@ namespace atomicassets {
 
         uint64_t primary_key() const { return (uint64_t) template_id; }
     };
-
     typedef multi_index <name("templates"), templates_s> templates_t;
+
+
+    //Scope: collection_name
+    struct template_mutables_s {
+        int32_t          template_id;
+        name             schema_name;
+        vector <uint8_t> mutable_serialized_data;
+
+        uint64_t primary_key() const { return (uint64_t) template_id; }
+    };
+    typedef multi_index <name("tmplmutables"), template_mutables_s> template_mutables_t;
 
 
     //Scope: owner
@@ -104,8 +145,20 @@ namespace atomicassets {
 
         uint64_t primary_key() const { return asset_id; };
     };
-
     typedef multi_index <name("assets"), assets_s> assets_t;
+
+
+    struct holders_s {
+        uint64_t         asset_id;
+        name             holder;
+        name             owner;
+
+        uint64_t primary_key() const { return asset_id; };
+        uint64_t by_holder() const { return holder.value; };
+    };
+    typedef multi_index <name("holders"), holders_s,  
+        indexed_by<name("holder"), const_mem_fun <holders_s, uint64_t, &holders_s::by_holder>>>
+    holders_t;
 
 
     struct offers_s {
@@ -123,11 +176,11 @@ namespace atomicassets {
 
         uint64_t by_recipient() const { return recipient.value; };
     };
-
     typedef multi_index <name("offers"), offers_s,
         indexed_by < name("sender"), const_mem_fun < offers_s, uint64_t, &offers_s::by_sender>>,
     indexed_by <name("recipient"), const_mem_fun < offers_s, uint64_t, &offers_s::by_recipient>>>
     offers_t;
+
 
     struct balances_s {
         name           owner;
@@ -135,8 +188,7 @@ namespace atomicassets {
 
         uint64_t primary_key() const { return owner.value; };
     };
-
-    typedef multi_index <name("balances"), balances_s>       balances_t;
+    typedef multi_index <name("balances"), balances_s>         balances_t;
 
 
     struct config_s {
@@ -146,30 +198,37 @@ namespace atomicassets {
         vector <FORMAT>          collection_format = {};
         vector <extended_symbol> supported_tokens  = {};
     };
-    typedef singleton <name("config"), config_s>             config_t;
+    typedef singleton <name("config"), config_s>               config_t;
+
 
     struct tokenconfigs_s {
         name        standard = name("atomicassets");
-        std::string version  = string("1.2.3");
+        std::string version  = string("2.0.0");
     };
-    typedef singleton <name("tokenconfigs"), tokenconfigs_s> tokenconfigs_t;
+    typedef singleton <name("tokenconfigs"), tokenconfigs_s>   tokenconfigs_t;
 
+    /*
+        *********************
+        *** Table Fetches ***
+        *********************
+    */
 
-    collections_t  collections  = collections_t(ATOMICASSETS_ACCOUNT, ATOMICASSETS_ACCOUNT.value);
-    offers_t       offers       = offers_t(ATOMICASSETS_ACCOUNT, ATOMICASSETS_ACCOUNT.value);
-    balances_t     balances     = balances_t(ATOMICASSETS_ACCOUNT, ATOMICASSETS_ACCOUNT.value);
-    config_t       config       = config_t(ATOMICASSETS_ACCOUNT, ATOMICASSETS_ACCOUNT.value);
-    tokenconfigs_t tokenconfigs = tokenconfigs_t(ATOMICASSETS_ACCOUNT, ATOMICASSETS_ACCOUNT.value);
+    author_swaps_t      get_author_swaps() {return author_swaps_t(get_self(), get_self().value);}
+    collections_t       get_collections() {return collections_t(get_self(), get_self().value);}
+    collections_t       get_collections_data() {return collections_t(get_self(), name("coldata").value);}
 
-    assets_t get_assets(name acc) {
-        return assets_t(ATOMICASSETS_ACCOUNT, acc.value);
-    }
+    offers_t            get_offers() {return offers_t(get_self(), get_self().value);}
+    balances_t          get_balances() {return balances_t(get_self(), get_self().value);}
+    config_t            get_config() {return config_t(get_self(), get_self().value);}
+    tokenconfigs_t      get_tokenconfigs() {return tokenconfigs_t(get_self(), get_self().value);}
 
-    schemas_t get_schemas(name collection_name) {
-        return schemas_t(ATOMICASSETS_ACCOUNT, collection_name.value);
-    }
+    schemas_t           get_schemas(name collection_name) {return schemas_t(get_self(), collection_name.value);}
+    schema_types_t      get_schema_types(name collection_name) {return schema_types_t(get_self(), collection_name.value);}
 
-    templates_t get_templates(name collection_name) {
-        return templates_t(ATOMICASSETS_ACCOUNT, collection_name.value);
-    }
+    templates_t         get_templates(name collection_name) {return templates_t(get_self(), collection_name.value);}
+    template_mutables_t get_template_mutables(name collection_name) {return template_mutables_t(get_self(), collection_name.value);}
+
+    assets_t            get_assets(name owner) {return assets_t(get_self(), owner.value);}
+    holders_t           get_holders() {return holders_t(get_self(), get_self().value);}
+
 };

--- a/include/atomicassets-interface.hpp
+++ b/include/atomicassets-interface.hpp
@@ -129,7 +129,7 @@ namespace atomicassets {
 
         uint64_t primary_key() const { return (uint64_t) template_id; }
     };
-    typedef multi_index <name("tmplmutables"), template_mutables_s> template_mutables_t;
+    typedef multi_index <name("templates2"), template_mutables_s> template_mutables_t;
 
 
     //Scope: owner
@@ -215,7 +215,6 @@ namespace atomicassets {
 
     author_swaps_t      get_author_swaps() {return author_swaps_t(get_self(), get_self().value);}
     collections_t       get_collections() {return collections_t(get_self(), get_self().value);}
-    collections_t       get_collections_data() {return collections_t(get_self(), name("coldata").value);}
 
     offers_t            get_offers() {return offers_t(get_self(), get_self().value);}
     balances_t          get_balances() {return balances_t(get_self(), get_self().value);}

--- a/include/atomicassets.hpp
+++ b/include/atomicassets.hpp
@@ -250,6 +250,15 @@ public:
         string memo
     );
 
+    ACTION logmove(
+        name collection_name,
+        name owner,
+        name from,
+        name to,
+        vector <uint64_t> asset_ids,
+        string memo
+    );
+
     ACTION lognewoffer(
         uint64_t offer_id,
         name sender,

--- a/include/atomicassets.hpp
+++ b/include/atomicassets.hpp
@@ -11,7 +11,7 @@ using namespace atomicdata;
 
 
 static constexpr double MAX_MARKET_FEE = 0.15;
-
+static const string MISSING_COLLECTION_AUTH = "Missing authorization for this collection";
 
 CONTRACT atomicassets : public contract {
 public:
@@ -352,25 +352,27 @@ private:
         vector <extended_symbol> supported_tokens  = {};
     };
     typedef singleton <name("config"), config_s>               config_t;
-    // https://github.com/EOSIO/eosio.cdt/issues/280
-    typedef multi_index <name("config"), config_s>             config_t_for_abi;
+
 
     TABLE tokenconfigs_s {
         name        standard = name("atomicassets");
         std::string version  = string("1.3.1");
     };
     typedef singleton <name("tokenconfigs"), tokenconfigs_s>   tokenconfigs_t;
-    // https://github.com/EOSIO/eosio.cdt/issues/280
-    typedef multi_index <name("tokenconfigs"), tokenconfigs_s> tokenconfigs_t_for_abi;
 
+    // Table Fetches
+    collections_t  get_collections() {return collections_t(get_self(), get_self().value);}
+    collections_t  get_collections_data() {return collections_t(get_self(), name("coldata").value);}
+    offers_t       get_offers() {return offers_t(get_self(), get_self().value);}
+    balances_t     get_balances() {return balances_t(get_self(), get_self().value);}
+    config_t       get_config() {return config_t(get_self(), get_self().value);}
+    tokenconfigs_t get_tokenconfigs() {return tokenconfigs_t(get_self(), get_self().value);}
 
-    collections_t  collections  = collections_t(get_self(), get_self().value);
-    offers_t       offers       = offers_t(get_self(), get_self().value);
-    balances_t     balances     = balances_t(get_self(), get_self().value);
-    config_t       config       = config_t(get_self(), get_self().value);
-    tokenconfigs_t tokenconfigs = tokenconfigs_t(get_self(), get_self().value);
+    assets_t       get_assets(name acc) {return assets_t(get_self(), acc.value);}
+    schemas_t      get_schemas(name collection_name) {return schemas_t(get_self(), collection_name.value);}
+    templates_t    get_templates(name collection_name) {return templates_t(get_self(), collection_name.value);}
 
-
+    // Internal Functions
     void internal_transfer(
         name from,
         name to,
@@ -396,16 +398,12 @@ private:
     );
 
     void check_has_collection_auth(
-        name account_to_check,
-        name collection_name,
-        string error_message
+        name & account_to_check,
+        const collections_s & collection_itr
     );
 
-    void check_name_length(ATTRIBUTE_MAP data);
+    void check_name_length(ATTRIBUTE_MAP & data);
 
-    assets_t get_assets(name acc);
+    void coldata_cleanup(name & collection_name, const collections_s & collection_itr);
 
-    schemas_t get_schemas(name collection_name);
-
-    templates_t get_templates(name collection_name);
 };

--- a/include/atomicassets.hpp
+++ b/include/atomicassets.hpp
@@ -320,6 +320,12 @@ public:
 
 private:
 
+    /*
+        **************
+        *** Tables ***
+        **************
+    */
+
     TABLE author_swaps_s {
         name             collection_name;
         name             current_author;
@@ -328,8 +334,8 @@ private:
 
         uint64_t primary_key() const { return collection_name.value; };
     };
-
     typedef multi_index <name("authorswaps"), author_swaps_s> author_swaps_t;
+
 
     TABLE collections_s {
         name             collection_name;
@@ -342,7 +348,6 @@ private:
 
         uint64_t primary_key() const { return collection_name.value; };
     };
-
     typedef multi_index <name("collections"), collections_s> collections_t;
 
 
@@ -353,8 +358,8 @@ private:
 
         uint64_t primary_key() const { return schema_name.value; }
     };
-
     typedef multi_index <name("schemas"), schemas_s> schemas_t;
+
 
     //Scope: collection_name
     TABLE schema_types_s {
@@ -363,8 +368,8 @@ private:
 
         uint64_t primary_key() const { return schema_name.value; }
     };
-
     typedef multi_index <name("schematypes"), schema_types_s> schema_types_t;
+
 
     //Scope: collection_name
     TABLE templates_s {
@@ -378,8 +383,8 @@ private:
 
         uint64_t primary_key() const { return (uint64_t) template_id; }
     };
-
     typedef multi_index <name("templates"), templates_s> templates_t;
+
 
     //Scope: collection_name
     TABLE template_mutables_s {
@@ -389,8 +394,8 @@ private:
 
         uint64_t primary_key() const { return (uint64_t) template_id; }
     };
-
     typedef multi_index <name("tmplmutables"), template_mutables_s> template_mutables_t;
+
 
     //Scope: owner
     TABLE assets_s {
@@ -405,8 +410,8 @@ private:
 
         uint64_t primary_key() const { return asset_id; };
     };
-
     typedef multi_index <name("assets"), assets_s> assets_t;
+
 
     TABLE holders_s {
         uint64_t         asset_id;
@@ -416,10 +421,10 @@ private:
         uint64_t primary_key() const { return asset_id; };
         uint64_t by_holder() const { return holder.value; };
     };
-
     typedef multi_index <name("holders"), holders_s,  
         indexed_by<name("holder"), const_mem_fun <holders_s, uint64_t, &holders_s::by_holder>>>
     holders_t;
+
 
     TABLE offers_s {
         uint64_t          offer_id;
@@ -436,11 +441,11 @@ private:
 
         uint64_t by_recipient() const { return recipient.value; };
     };
-
     typedef multi_index <name("offers"), offers_s,
         indexed_by < name("sender"), const_mem_fun < offers_s, uint64_t, &offers_s::by_sender>>,
     indexed_by <name("recipient"), const_mem_fun < offers_s, uint64_t, &offers_s::by_recipient>>>
     offers_t;
+
 
     TABLE balances_s {
         name           owner;
@@ -448,7 +453,6 @@ private:
 
         uint64_t primary_key() const { return owner.value; };
     };
-
     typedef multi_index <name("balances"), balances_s>         balances_t;
 
 
@@ -464,11 +468,16 @@ private:
 
     TABLE tokenconfigs_s {
         name        standard = name("atomicassets");
-        std::string version  = string("1.3.1");
+        std::string version  = string("2.0.0");
     };
     typedef singleton <name("tokenconfigs"), tokenconfigs_s>   tokenconfigs_t;
 
-    // Table Fetches
+    /*
+        *********************
+        *** Table Fetches ***
+        *********************
+    */
+
     author_swaps_t      get_author_swaps() {return author_swaps_t(get_self(), get_self().value);}
     collections_t       get_collections() {return collections_t(get_self(), get_self().value);}
     collections_t       get_collections_data() {return collections_t(get_self(), name("coldata").value);}
@@ -487,7 +496,11 @@ private:
     assets_t            get_assets(name owner) {return assets_t(get_self(), owner.value);}
     holders_t           get_holders() {return holders_t(get_self(), get_self().value);}
 
-    // Internal Functions
+    /*
+        **************************
+        *** Internal Functions ***
+        **************************
+    */
 
     void internal_create_template(
         name authorized_creator,

--- a/include/atomicassets.hpp
+++ b/include/atomicassets.hpp
@@ -13,7 +13,6 @@ using namespace atomicdata;
 static constexpr double MAX_MARKET_FEE = 0.15;
 static constexpr uint32_t AUTHOR_SWAP_TIME_DELTA = 60 * 60 * 24 * 7; // 1 week, valid for 1 week
 
-static const string MISSING_COLLECTION_AUTH = "Missing authorization for this collection";
 static constexpr char COLLECTION_NOT_FOUND[] = "No collection with this name exists";
 
 CONTRACT atomicassets : public contract {
@@ -394,7 +393,7 @@ private:
 
         uint64_t primary_key() const { return (uint64_t) template_id; }
     };
-    typedef multi_index <name("tmplmutables"), template_mutables_s> template_mutables_t;
+    typedef multi_index <name("templates2"), template_mutables_s> template_mutables_t;
 
 
     //Scope: owner
@@ -480,7 +479,6 @@ private:
 
     author_swaps_t      get_author_swaps() {return author_swaps_t(get_self(), get_self().value);}
     collections_t       get_collections() {return collections_t(get_self(), get_self().value);}
-    collections_t       get_collections_data() {return collections_t(get_self(), name("coldata").value);}
 
     offers_t            get_offers() {return offers_t(get_self(), get_self().value);}
     balances_t          get_balances() {return balances_t(get_self(), get_self().value);}
@@ -526,17 +524,20 @@ private:
         asset quantity
     );
 
-    void notify_collection_accounts(
-        name collection_name
+    vector<name> partial_read_collection(
+        name & collection_name_,
+        bool type
     );
 
     void check_has_collection_auth(
         name & account_to_check,
-        const collections_s & collection_itr
+        name & collection_name
+    );
+
+    void notify_collection_accounts(
+        name collection_name
     );
 
     void check_name_length(ATTRIBUTE_MAP & data);
-
-    void coldata_cleanup(name & collection_name, const collections_s & collection_itr);
 
 };

--- a/include/atomicassets.hpp
+++ b/include/atomicassets.hpp
@@ -14,7 +14,7 @@ static constexpr double MAX_MARKET_FEE = 0.15;
 static constexpr uint32_t AUTHOR_SWAP_TIME_DELTA = 60 * 60 * 24 * 7; // 1 week, valid for 1 week
 
 static const string MISSING_COLLECTION_AUTH = "Missing authorization for this collection";
-static const string COLLECTION_NOT_FOUND = "No collection with this name exists";
+static constexpr char COLLECTION_NOT_FOUND[] = "No collection with this name exists";
 
 CONTRACT atomicassets : public contract {
 public:

--- a/include/atomicdata.hpp
+++ b/include/atomicdata.hpp
@@ -37,6 +37,12 @@ namespace atomicdata {
         std::string type;
     };
 
+    struct FORMAT_TYPE {
+        std::string name;
+        std::string mediatype;
+        std::string info;
+    };
+
     static constexpr uint64_t RESERVED = 4;
 
 

--- a/include/checkformat.hpp
+++ b/include/checkformat.hpp
@@ -29,7 +29,7 @@ For a format to be valid, three things are checked:
 Note: This could all be done a lot cleaner by using regex or similar libraries
       However, using them would bloat up the contract size significantly.
 */
-void check_format(vector <FORMAT> lines) {
+void check_format(vector <FORMAT> & lines) {
 
     bool found_name = false;
 

--- a/include/checkformat.hpp
+++ b/include/checkformat.hpp
@@ -35,10 +35,10 @@ void check_format(vector <FORMAT> & lines) {
 
     vector <string> attribute_names = {};
 
-    for (FORMAT line : lines) {
+    for (FORMAT & line : lines) {
 
-        string name = line.name;
-        string type = line.type;
+        string & name = line.name;
+        string & type = line.type;
 
         check(name.length() != 0, "An attribute's name can't be empty");
         check(name.length() <= 64, "An attribute's name can only be 64 characters max");

--- a/src/atomicassets.cpp
+++ b/src/atomicassets.cpp
@@ -1167,6 +1167,13 @@ ACTION atomicassets::burnasset(
         check(template_itr->burnable, "The asset is not burnable");
     };
 
+    holders_t holders = get_holders();
+
+    // Checks to see if the asset has been rented out & erases the "holdership"
+    auto holders_itr = holders.find(asset_id);
+    if (holders_itr != holders.end()){
+        holders.erase(holders_itr);
+    }    
 
     if (asset_itr->backed_tokens.size() != 0) {
         auto balances = get_balances();

--- a/src/atomicassets.cpp
+++ b/src/atomicassets.cpp
@@ -243,7 +243,7 @@ ACTION atomicassets::setcoldata(
     ATTRIBUTE_MAP data
 ) {
     collections_t collections = get_collections();
-    auto collection_itr = collections.require_find(collection_name.value, "COL NOT FOUND");
+    auto collection_itr = collections.require_find(collection_name.value, COLLECTION_NOT_FOUND);
 
     require_auth(collection_itr->author);
 
@@ -284,7 +284,7 @@ ACTION atomicassets::addcolauth(
     name account_to_add
 ) {
     collections_t collections = get_collections();
-    auto collection_itr = collections.require_find(collection_name.value, "COL NOT FOUND");
+    auto collection_itr = collections.require_find(collection_name.value, COLLECTION_NOT_FOUND);
 
     require_auth(collection_itr->author);
 
@@ -315,7 +315,7 @@ ACTION atomicassets::remcolauth(
     name account_to_remove
 ) {
     collections_t collections = get_collections();
-    auto collection_itr = collections.require_find(collection_name.value, "COL NOT FOUND");
+    auto collection_itr = collections.require_find(collection_name.value, COLLECTION_NOT_FOUND);
 
     require_auth(collection_itr->author);
     vector <name> authorized_accounts = collection_itr->authorized_accounts;
@@ -347,7 +347,7 @@ ACTION atomicassets::addnotifyacc(
     name account_to_add
 ) {
     collections_t collections = get_collections();
-    auto collection_itr = collections.require_find(collection_name.value, "COL NOT FOUND");
+    auto collection_itr = collections.require_find(collection_name.value, COLLECTION_NOT_FOUND);
 
     require_auth(collection_itr->author);
 
@@ -380,7 +380,7 @@ ACTION atomicassets::remnotifyacc(
     name account_to_remove
 ) {
     collections_t collections = get_collections();
-    auto collection_itr = collections.require_find(collection_name.value, "COL NOT FOUND");
+    auto collection_itr = collections.require_find(collection_name.value, COLLECTION_NOT_FOUND);
 
     require_auth(collection_itr->author);
     vector <name> notify_accounts = collection_itr->notify_accounts;
@@ -409,7 +409,7 @@ ACTION atomicassets::setmarketfee(
     double market_fee
 ) {
     collections_t collections = get_collections();
-    auto collection_itr = collections.require_find(collection_name.value, "COL NOT FOUND");
+    auto collection_itr = collections.require_find(collection_name.value, COLLECTION_NOT_FOUND);
 
     require_auth(collection_itr->author);
 
@@ -434,7 +434,7 @@ ACTION atomicassets::forbidnotify(
     name collection_name
 ) {
     collections_t collections = get_collections();
-    auto collection_itr = collections.require_find(collection_name.value, "COL NOT FOUND");
+    auto collection_itr = collections.require_find(collection_name.value, COLLECTION_NOT_FOUND);
 
     require_auth(collection_itr->author);
 
@@ -461,7 +461,7 @@ ACTION atomicassets::createauswap(
     bool owner
 ) {
     collections_t collections = get_collections();
-    auto collection_itr = collections.require_find(collection_name.value, "COL NOT FOUND");
+    auto collection_itr = collections.require_find(collection_name.value, COLLECTION_NOT_FOUND);
 
     if (owner){
         require_auth(permission_level{collection_itr->author, name("owner")});
@@ -491,7 +491,7 @@ ACTION atomicassets::acceptauswap(
     name collection_name
 ) {
     collections_t collections = get_collections();
-    auto collection_itr = collections.require_find(collection_name.value, "COL NOT FOUND");
+    auto collection_itr = collections.require_find(collection_name.value, COLLECTION_NOT_FOUND);
 
     author_swaps_t authorswaps = get_author_swaps();
     auto author_swaps_itr = authorswaps.require_find(collection_name.value,
@@ -526,7 +526,7 @@ ACTION atomicassets::rejectauswap(
     name collection_name
 ) {
     collections_t collections = get_collections();
-    auto collection_itr = collections.require_find(collection_name.value, "COL NOT FOUND");
+    auto collection_itr = collections.require_find(collection_name.value, COLLECTION_NOT_FOUND);
 
     author_swaps_t authorswaps = get_author_swaps();
     auto author_swaps_itr = authorswaps.require_find(collection_name.value,
@@ -556,7 +556,7 @@ ACTION atomicassets::createschema(
 ) {
 
     collections_t collections = get_collections();
-    auto collection_itr = collections.require_find(collection_name.value, "COL NOT FOUND");
+    auto collection_itr = collections.require_find(collection_name.value, COLLECTION_NOT_FOUND);
 
     check_has_collection_auth(
         authorized_creator,
@@ -591,7 +591,7 @@ ACTION atomicassets::extendschema(
     vector <FORMAT> schema_format_extension
 ) {
     collections_t collections = get_collections();
-    auto collection_itr = collections.require_find(collection_name.value, "COL NOT FOUND");
+    auto collection_itr = collections.require_find(collection_name.value, COLLECTION_NOT_FOUND);
 
     check_has_collection_auth(
         authorized_editor,
@@ -626,7 +626,7 @@ ACTION atomicassets::setschematyp(
     vector <FORMAT_TYPE> schema_format_type
 ) {
     collections_t collections = get_collections();
-    auto collection_itr = collections.require_find(collection_name.value, "COL NOT FOUND");
+    auto collection_itr = collections.require_find(collection_name.value, COLLECTION_NOT_FOUND);
 
     check_has_collection_auth(
         authorized_editor,
@@ -714,7 +714,7 @@ ACTION atomicassets::deltemplate(
     int32_t template_id
 ) {
     collections_t collections = get_collections();
-    auto collection_itr = collections.require_find(collection_name.value, "COL NOT FOUND");
+    auto collection_itr = collections.require_find(collection_name.value, COLLECTION_NOT_FOUND);
 
     check_has_collection_auth(
         authorized_editor,
@@ -742,7 +742,7 @@ ACTION atomicassets::locktemplate(
     int32_t template_id
 ) {
     collections_t collections = get_collections();
-    auto collection_itr = collections.require_find(collection_name.value, "COL NOT FOUND");
+    auto collection_itr = collections.require_find(collection_name.value, COLLECTION_NOT_FOUND);
 
     check_has_collection_auth(
         authorized_editor,
@@ -776,7 +776,7 @@ ACTION atomicassets::redtemplmax(
     uint32_t new_max_supply
 ) {
     collections_t collections = get_collections();
-    auto collection_itr = collections.require_find(collection_name.value, "COL NOT FOUND");
+    auto collection_itr = collections.require_find(collection_name.value, COLLECTION_NOT_FOUND);
 
     check_has_collection_auth(
         authorized_editor,
@@ -819,7 +819,7 @@ ACTION atomicassets::mintasset(
     vector <asset> tokens_to_back
 ) {
     collections_t collections = get_collections();
-    auto collection_itr = collections.require_find(collection_name.value, "COL NOT FOUND");
+    auto collection_itr = collections.require_find(collection_name.value, COLLECTION_NOT_FOUND);
 
     check_has_collection_auth(
         authorized_minter,
@@ -922,7 +922,7 @@ ACTION atomicassets::setassetdata(
         "No asset with this id exists");
 
     collections_t collections = get_collections();
-    auto collection_itr = collections.require_find(asset_itr->collection_name.value, "COL NOT FOUND");
+    auto collection_itr = collections.require_find(asset_itr->collection_name.value, COLLECTION_NOT_FOUND);
 
     check_has_collection_auth(
         authorized_editor,
@@ -968,7 +968,7 @@ ACTION atomicassets::settempldata(
     ATTRIBUTE_MAP new_mutable_data
 ) {
     collections_t collections = get_collections();
-    auto collection_itr = collections.require_find(collection_name.value, "COL NOT FOUND");
+    auto collection_itr = collections.require_find(collection_name.value, COLLECTION_NOT_FOUND);
 
     check_has_collection_auth(
         authorized_editor,
@@ -1612,7 +1612,7 @@ void atomicassets::internal_create_template(
     ATTRIBUTE_MAP mutable_data
 ) { 
     collections_t collections = get_collections();
-    auto collection_itr = collections.require_find(collection_name.value, "COL NOT FOUND");
+    auto collection_itr = collections.require_find(collection_name.value, COLLECTION_NOT_FOUND);
 
     check_has_collection_auth(
         authorized_creator,
@@ -1846,7 +1846,7 @@ void atomicassets::notify_collection_accounts(
     name collection_name
 ) {
     collections_t collections = get_collections();
-    auto collection_itr = collections.require_find(collection_name.value, "COL NOT FOUND");
+    auto collection_itr = collections.require_find(collection_name.value, COLLECTION_NOT_FOUND);
 
     for (const name &notify_account : collection_itr->notify_accounts) {
         require_recipient(notify_account);

--- a/src/atomicassets.cpp
+++ b/src/atomicassets.cpp
@@ -225,7 +225,6 @@ ACTION atomicassets::createcol(
     auto collections_data = get_collections_data();
     collections_data.emplace(author, [&](auto &_collection_data) {
         _collection_data.collection_name = collection_name;
-        _collection_data.author = author;
         _collection_data.serialized_data = serialize(data, current_config.collection_format);
     });
 }
@@ -258,7 +257,6 @@ ACTION atomicassets::setcoldata(
     if (collection_data_itr == collections_data.end()){
         collections_data.emplace(collection_itr->author, [&](auto &_collection_data){
             _collection_data.collection_name = collection_itr->collection_name;
-            _collection_data.author = collection_itr->author;
             _collection_data.serialized_data = serialize(data, current_config.collection_format);
         });
     } else {
@@ -1912,7 +1910,6 @@ void atomicassets::coldata_cleanup(name & collection_name, const collections_s &
     if (collection_data_itr == collections_data.end()){
         collections_data.emplace(collection_itr.author, [&](auto &_collection_data){
             _collection_data.collection_name = collection_itr.collection_name;
-            _collection_data.author = collection_itr.author;
             _collection_data.serialized_data = collection_itr.serialized_data;
         });
     }

--- a/src/atomicassets.cpp
+++ b/src/atomicassets.cpp
@@ -1864,19 +1864,19 @@ void atomicassets::internal_decrease_balance(
     + 128               // Row + Primary Key
     + 8 + 8             // author index + type = 16
     + 8 + 1 + 7         // allow_notify index + type + alignment / padding = 16
-    + 24                // authorized_accounts vector
+    + 24 + 8            // authorized_accounts vector + index = 32
     + (8 * R={1|24})    // 8 Bytes for each element in the authorized_accounts, up to 24, total ranging from 8 to 192
 
-* Total Bytes R={192|376}
+* Total Bytes R={200|384}
 
 * Notify Bytes Math = 
     + 128               // Row + Primary Key
     + 8 + 8             // author index + type = 16
     + 8 + 1 + 7         // allow_notify index + type + alignment / padding = 16
-    + 24 + 24           // authorized_accounts + notify_accounts vectors
+    + 24 + 24 + 16      // authorized_accounts + notify_accounts vectors + indices = 64
     + (8 * R={1|48})    // 8 Bytes for each element in the authorized_accounts, up to 24, total ranging from 8 to 384
 
-* Total Bytes R={216|592}
+* Total Bytes R={232|608}
 
 */
 
@@ -1891,7 +1891,7 @@ vector<name> atomicassets::partial_read_collection(
     int data_size = eosio::internal_use_do_not_use::db_get_i64(collection_itr, nullptr, 0);
     check(data_size > 0, COLLECTION_NOT_FOUND);
 
-    int read_size = min(data_size, !type ? 376 : 592); // Authorized Accounts vs Notify Accounts
+    int read_size = min(data_size, !type ? 384 : 608); // Authorized Accounts vs Notify Accounts
     vector<char> buffer(read_size);
     eosio::internal_use_do_not_use::db_get_i64(collection_itr, buffer.data(), read_size);
 

--- a/src/atomicassets.cpp
+++ b/src/atomicassets.cpp
@@ -728,6 +728,12 @@ ACTION atomicassets::deltemplate(
     check(template_itr->issued_supply == 0,
         "Can't delete a template that has any assets issued");
 
+    template_mutables_t template_mutables = get_template_mutables(collection_name);
+    auto template_mutables_itr = template_mutables.find(template_id);
+    if (template_mutables_itr != template_mutables.end()){
+        template_mutables.erase(template_mutables_itr);
+    }
+
     collection_templates.erase(template_itr);
 }
 


### PR DESCRIPTION
Based on the list of features proposed here: https://github.com/wax-office-of-inspector-general/WAX-RFP/discussions/11

- Merges all of the dev feature branches (1-8, 300)
- CPU Optimized
- Table calls rewritten to explicit initializations within each action, rather than implicit initialization at the header level
- atomicassets-interface.hpp updated
- 99% complete for the contract itself, just down to bug fixing & auditing

Edit:
- Added partial reading support for collections' table, greatly improving CPU performance
- Added max limit of 24 authorized_editors & 24 notify_accounts to facilitate the partial reading support
- Might need some significant auditing in this department for potential exploits